### PR TITLE
#24 Updated Microsoft.Powershell.SDK dependecy to 7.2.23 to fix issue…

### DIFF
--- a/Frends.PowerShell.RunCommand/CHANGELOG.md
+++ b/Frends.PowerShell.RunCommand/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-10-08
+### Changed
+- Updated PowerShell version to 7.2.23
+
 ## [1.0.2] - 2022-12-29
 ### Fixed
 - Memory leak fix by unloading assembly context after Task execution.

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.Tests/TaskUserInterfaceTests.cs
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.Tests/TaskUserInterfaceTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Security;
+using Frends.PowerShell.RunCommand;
+using NUnit.Framework;
+
+namespace Frends.PowerShell.RunScript.Tests;
+
+public class TaskUserInterfaceTests
+{
+    /// <summary>
+    /// This user interface is a dummy implementation that does not do anything.
+    /// Ensure that most methods can be called without exceptions.
+    /// </summary>
+    [Test]
+    public void TestTheWholeThing()
+    {
+        var taskUserInterface = new TaskUserInterface();
+        taskUserInterface.Write("Hello, World!");
+        taskUserInterface.Write(ConsoleColor.Black, ConsoleColor.White, "Hello, World!");
+        taskUserInterface.WriteLine("Hello, World!");
+        taskUserInterface.WriteErrorLine("Hello, World!");
+        taskUserInterface.WriteDebugLine("Hello, World!");
+        taskUserInterface.WriteProgress(1, new ProgressRecord(1, "Activity", "Status"));
+        taskUserInterface.WriteVerboseLine("Hello, World!");
+        taskUserInterface.WriteWarningLine("Hello, World!");
+        taskUserInterface.ReadLineAsSecureString();
+
+        Assert.AreEqual("", taskUserInterface.ReadLine());
+        Assert.AreEqual(1, taskUserInterface.PromptForChoice("Caption", "Message", new Collection<ChoiceDescription>(), 1));
+
+        var answer = taskUserInterface.Prompt("Caption", "Message", new Collection<FieldDescription> { new ("Name") });
+        Assert.AreEqual(1, answer.Count);
+
+        Assert.Throws<NotImplementedException>(() => taskUserInterface.PromptForCredential("Caption", "Message", "UserName", "TargetName"));
+        Assert.Throws<NotImplementedException>(() => taskUserInterface.PromptForCredential("Caption", "Message", "UserName", "TargetName", PSCredentialTypes.Domain, PSCredentialUIOptions.Default));
+
+    }
+}

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.csproj
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.csproj
@@ -7,7 +7,7 @@
 	<AssemblyName>Frends.PowerShell.RunCommand</AssemblyName>
 	<RootNamespace>Frends.PowerShell.RunCommand</RootNamespace>
 
-	<Version>1.0.2</Version>
+	<Version>1.0.3</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-	<PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.1" />
+	<PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.23" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.csproj
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.csproj
@@ -7,7 +7,7 @@
 	<AssemblyName>Frends.PowerShell.RunCommand</AssemblyName>
 	<RootNamespace>Frends.PowerShell.RunCommand</RootNamespace>
 
-	<Version>1.0.3</Version>
+	<Version>1.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.PowerShell.RunScript/CHANGELOG.md
+++ b/Frends.PowerShell.RunScript/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-10-08
+### Changed
+- Updated PowerShell version to 7.2.23
+
  [1.0.2] - 2022-12-21
 ### Changed
 - Memory leak fix.

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.Tests/TaskUserInterfaceTests.cs
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.Tests/TaskUserInterfaceTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Security;
+using NUnit.Framework;
+
+namespace Frends.PowerShell.RunScript.Tests;
+
+public class TaskUserInterfaceTests
+{
+    /// <summary>
+    /// This user interface is a dummy implementation that does not do anything.
+    /// Ensure that most methods can be called without exceptions.
+    /// </summary>
+    [Test]
+    public void TestTheWholeThing()
+    {
+        var taskUserInterface = new TaskUserInterface();
+        taskUserInterface.Write("Hello, World!");
+        taskUserInterface.Write(ConsoleColor.Black, ConsoleColor.White, "Hello, World!");
+        taskUserInterface.WriteLine("Hello, World!");
+        taskUserInterface.WriteErrorLine("Hello, World!");
+        taskUserInterface.WriteDebugLine("Hello, World!");
+        taskUserInterface.WriteProgress(1, new ProgressRecord(1, "Activity", "Status"));
+        taskUserInterface.WriteVerboseLine("Hello, World!");
+        taskUserInterface.WriteWarningLine("Hello, World!");
+        taskUserInterface.ReadLineAsSecureString();
+
+        Assert.AreEqual("", taskUserInterface.ReadLine());
+        Assert.AreEqual(1, taskUserInterface.PromptForChoice("Caption", "Message", new Collection<ChoiceDescription>(), 1));
+
+        var answer = taskUserInterface.Prompt("Caption", "Message", new Collection<FieldDescription> { new ("Name") });
+        Assert.AreEqual(1, answer.Count);
+
+        Assert.Throws<NotImplementedException>(() => taskUserInterface.PromptForCredential("Caption", "Message", "UserName", "TargetName"));
+        Assert.Throws<NotImplementedException>(() => taskUserInterface.PromptForCredential("Caption", "Message", "UserName", "TargetName", PSCredentialTypes.Domain, PSCredentialUIOptions.Default));
+
+    }
+}

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.csproj
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.csproj
@@ -6,8 +6,8 @@
 	<IncludeSource>true</IncludeSource>
 	<AssemblyName>Frends.PowerShell.RunScript</AssemblyName>
 	<RootNamespace>Frends.PowerShell.RunScript</RootNamespace>
-    
-	<Version>1.0.3</Version>
+
+	<Version>1.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.csproj
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.csproj
@@ -7,7 +7,7 @@
 	<AssemblyName>Frends.PowerShell.RunScript</AssemblyName>
 	<RootNamespace>Frends.PowerShell.RunScript</RootNamespace>
     
-	<Version>1.0.2</Version>
+	<Version>1.0.3</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
-	<PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.1" />
+	<PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.23" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
… with running the Task in Frends 5.7+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the version of the PowerShell SDK to 7.2.23 for improved functionality.
	- Incremented version numbers for both the RunCommand and RunScript components to 1.1.0 to reflect the latest updates.
	- Introduced new test classes to validate the functionality of the TaskUserInterface for both components.

These changes enhance the performance, reliability, and test coverage of the applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->