### PR TITLE
enable executing from native PS

### DIFF
--- a/.github/workflows/RunCommand_build_and_test_on_push.yml
+++ b/.github/workflows/RunCommand_build_and_test_on_push.yml
@@ -5,14 +5,21 @@ on:
     branches-ignore:
       - main
     paths:
-      - 'Frends.PowerShell.RunCommand/**'
+      - "Frends.PowerShell.RunCommand/**"
   workflow_dispatch:
     paths:
-      - 'Frends.PowerShell.RunCommand/**'
-  
+      - "Frends.PowerShell.RunCommand/**"
+
 jobs:
-  build:
+  build-windows:
     uses: FrendsPlatform/FrendsTasks/.github/workflows/build_test.yml@main
+    with:
+      workdir: Frends.PowerShell.RunCommand
+    secrets:
+      badge_service_api_key: ${{ secrets.BADGE_SERVICE_API_KEY }}
+      test_feed_api_key: ${{ secrets.TASKS_TEST_FEED_API_KEY }}
+  build-linux:
+    uses: FrendsPlatform/FrendsTasks/.github/workflows/linux_build_test.yml@main
     with:
       workdir: Frends.PowerShell.RunCommand
     secrets:

--- a/.github/workflows/RunCommand_build_and_test_on_push.yml
+++ b/.github/workflows/RunCommand_build_and_test_on_push.yml
@@ -11,15 +11,8 @@ on:
       - "Frends.PowerShell.RunCommand/**"
 
 jobs:
-  build-windows:
+  build:
     uses: FrendsPlatform/FrendsTasks/.github/workflows/build_test.yml@main
-    with:
-      workdir: Frends.PowerShell.RunCommand
-    secrets:
-      badge_service_api_key: ${{ secrets.BADGE_SERVICE_API_KEY }}
-      test_feed_api_key: ${{ secrets.TASKS_TEST_FEED_API_KEY }}
-  build-linux:
-    uses: FrendsPlatform/FrendsTasks/.github/workflows/linux_build_test.yml@main
     with:
       workdir: Frends.PowerShell.RunCommand
     secrets:

--- a/.github/workflows/RunScript_build_and_test_on_push.yml
+++ b/.github/workflows/RunScript_build_and_test_on_push.yml
@@ -11,15 +11,8 @@ on:
       - "Frends.PowerShell.RunScript/**"
 
 jobs:
-  build-windows:
+  build:
     uses: FrendsPlatform/FrendsTasks/.github/workflows/build_test.yml@main
-    with:
-      workdir: Frends.PowerShell.RunScript
-    secrets:
-      badge_service_api_key: ${{ secrets.BADGE_SERVICE_API_KEY }}
-      test_feed_api_key: ${{ secrets.TASKS_TEST_FEED_API_KEY }}
-  build-linux:
-    uses: FrendsPlatform/FrendsTasks/.github/workflows/linux_build_test.yml@main
     with:
       workdir: Frends.PowerShell.RunScript
     secrets:

--- a/.github/workflows/RunScript_build_and_test_on_push.yml
+++ b/.github/workflows/RunScript_build_and_test_on_push.yml
@@ -5,18 +5,23 @@ on:
     branches-ignore:
       - main
     paths:
-      - 'Frends.PowerShell.RunScript/**'
+      - "Frends.PowerShell.RunScript/**"
   workflow_dispatch:
     paths:
-      - 'Frends.PowerShell.RunScript/**'
-  
+      - "Frends.PowerShell.RunScript/**"
 
 jobs:
-  build:
+  build-windows:
     uses: FrendsPlatform/FrendsTasks/.github/workflows/build_test.yml@main
     with:
       workdir: Frends.PowerShell.RunScript
     secrets:
       badge_service_api_key: ${{ secrets.BADGE_SERVICE_API_KEY }}
       test_feed_api_key: ${{ secrets.TASKS_TEST_FEED_API_KEY }}
-      
+  build-linux:
+    uses: FrendsPlatform/FrendsTasks/.github/workflows/linux_build_test.yml@main
+    with:
+      workdir: Frends.PowerShell.RunScript
+    secrets:
+      badge_service_api_key: ${{ secrets.BADGE_SERVICE_API_KEY }}
+      test_feed_api_key: ${{ secrets.TASKS_TEST_FEED_API_KEY }}

--- a/Frends.PowerShell.RunCommand/CHANGELOG.md
+++ b/Frends.PowerShell.RunCommand/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] - 2025-01-08
+### Added
+- Added option to run command using native PowerShell
+
 ## [1.2.0] - 2024-10-09
 ### Changed
 - Added explicit reference to Microsoft.Management.Infrastructure

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.Tests/TaskUserInterfaceTests.cs
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.Tests/TaskUserInterfaceTests.cs
@@ -31,7 +31,7 @@ public class TaskUserInterfaceTests
         Assert.AreEqual("", taskUserInterface.ReadLine());
         Assert.AreEqual(1, taskUserInterface.PromptForChoice("Caption", "Message", new Collection<ChoiceDescription>(), 1));
 
-        var answer = taskUserInterface.Prompt("Caption", "Message", new Collection<FieldDescription> { new ("Name") });
+        var answer = taskUserInterface.Prompt("Caption", "Message", new Collection<FieldDescription> { new("Name") });
         Assert.AreEqual(1, answer.Count);
 
         Assert.Throws<NotImplementedException>(() => taskUserInterface.PromptForCredential("Caption", "Message", "UserName", "TargetName"));

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.Tests/UnitTests.cs
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.Tests/UnitTests.cs
@@ -62,4 +62,28 @@ function Test-Switch {
 
         Assert.That(result.Result.Single(), Is.EqualTo(switchParameterValue));
     }
+
+    [Test]
+    public void RunScript_ShouldRunFromNativeShell()
+    {
+        var result = PowerShell.RunCommand(new RunCommandInput
+        {
+            Command = "New-TimeSpan",
+            Parameters = new[]
+            {
+                new PowerShellParameter
+                {
+                    Name = "Days",
+                    Value = "1"
+                },
+            },
+            ExecuteNativeShell = true
+        },
+        new RunOptions());
+
+        StringAssert.Contains("1", result.Result.First());
+        Assert.That(result.Result.Count, Is.EqualTo(11));
+
+    }
+
 }

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/Definitions/RunCommandInput.cs
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/Definitions/RunCommandInput.cs
@@ -26,6 +26,14 @@ public class RunCommandInput
     /// <example>false</example>
     [DefaultValue(false)]
     public bool LogInformationStream { get; set; }
+
+    /// <summary>
+    /// Define which version of PowerShell to use.
+    /// Useful in more complex scripts, as default version supports only basic usage
+    /// </summary>
+    /// <example>false</example>
+    [DefaultValue(false)]
+    public bool ExecuteNativeShell { get; set; }
 }
 
 /// <summary>

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.csproj
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand.csproj
@@ -7,7 +7,7 @@
 	<AssemblyName>Frends.PowerShell.RunCommand</AssemblyName>
 	<RootNamespace>Frends.PowerShell.RunCommand</RootNamespace>
 
-	<Version>1.2.0</Version>
+	<Version>1.3.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/PowerShell.cs
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/PowerShell.cs
@@ -104,6 +104,7 @@ public static class PowerShell
         }
         finally
         {
+            if (!process.HasExited) process.Kill();
             process.Close();
         }
 

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/PowerShell.cs
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/PowerShell.cs
@@ -36,7 +36,8 @@ public static class PowerShell
     {
         return DoAndHandleSession(options?.Session, (session) =>
         {
-            if (input.ExecuteNativeShell){
+            if (input.ExecuteNativeShell)
+            {
                 var tempScript = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.ps1");
                 try
                 {
@@ -55,22 +56,25 @@ public static class PowerShell
                 {
                     File.Delete(tempScript);
                 }
-            } else
-            return ExecuteCommand(input.Command, input.Parameters, input.LogInformationStream, session.PowerShell);
+            }
+            else
+                return ExecuteCommand(input.Command, input.Parameters, input.LogInformationStream, session.PowerShell);
         });
     }
-        private static PowerShellResult ExecuteProcess(string scriptPath, PowerShellParameter[] parameters){
+    private static PowerShellResult ExecuteProcess(string scriptPath, PowerShellParameter[] parameters)
+    {
         List<dynamic> results = new();
         List<string> errors = new();
 
-        
+
 
         using Process process = new();
         process.StartInfo = new()
         {
             FileName = "powershell.exe",
             Arguments = $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\" ",
-            UseShellExecute = false,CreateNoWindow = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
             RedirectStandardError = true,
             RedirectStandardOutput = true,
         };
@@ -133,7 +137,7 @@ public static class PowerShell
         try
         {
             var execution = powershell.Invoke();
-            var result = new PowerShellResult (
+            var result = new PowerShellResult(
                 // Powershell return values are usually wrapped inside of a powershell object, unwrap it or if it does not have a baseObject, return the actual object
                 execution?.Select(GetResultObject).ToList(),
                 GetErrorMessages(powershell.Streams.Error),

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/PowerShell.cs
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/PowerShell.cs
@@ -5,6 +5,7 @@ using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Text;
 
@@ -65,13 +66,11 @@ public static class PowerShell
     {
         List<dynamic> results = new();
         List<string> errors = new();
-
-
-
+        
         using Process process = new();
         process.StartInfo = new()
         {
-            FileName = "powershell.exe",
+            FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "powershell" : "pwsh",
             Arguments = $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\" ",
             UseShellExecute = false,
             CreateNoWindow = true,
@@ -79,17 +78,18 @@ public static class PowerShell
             RedirectStandardOutput = true,
         };
 
-        process.OutputDataReceived += (sender, args) =>
+        void ProcessOutputReceiver(object sender, DataReceivedEventArgs args)
         {
             if (!string.IsNullOrWhiteSpace(args.Data))
                 results.Add(args.Data);
         };
-
-        process.ErrorDataReceived += (sender, args) =>
+        void ProcessErrorReceiver(object sender, DataReceivedEventArgs args)
         {
             if (!string.IsNullOrWhiteSpace(args.Data))
                 errors.Add(args.Data);
         };
+        process.OutputDataReceived += ProcessOutputReceiver;
+        process.ErrorDataReceived += ProcessErrorReceiver;
 
         try
         {
@@ -105,6 +105,8 @@ public static class PowerShell
         finally
         {
             if (!process.HasExited) process.Kill();
+            process.OutputDataReceived -= ProcessOutputReceiver;
+            process.ErrorDataReceived -= ProcessErrorReceiver;
             process.Close();
         }
 

--- a/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/PowerShell.cs
+++ b/Frends.PowerShell.RunCommand/Frends.PowerShell.RunCommand/PowerShell.cs
@@ -66,7 +66,7 @@ public static class PowerShell
     {
         List<dynamic> results = new();
         List<string> errors = new();
-        
+
         using Process process = new();
         process.StartInfo = new()
         {

--- a/Frends.PowerShell.RunScript/CHANGELOG.md
+++ b/Frends.PowerShell.RunScript/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] - 2025-01-08
+### Added
+- Added option to run script using native PowerShell
+
 ## [1.2.0] - 2024-10-09
 ### Changed
 - Added explicit reference to Microsoft.Management.Infrastructure

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.Tests/TaskUserInterfaceTests.cs
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.Tests/TaskUserInterfaceTests.cs
@@ -30,7 +30,7 @@ public class TaskUserInterfaceTests
         Assert.AreEqual("", taskUserInterface.ReadLine());
         Assert.AreEqual(1, taskUserInterface.PromptForChoice("Caption", "Message", new Collection<ChoiceDescription>(), 1));
 
-        var answer = taskUserInterface.Prompt("Caption", "Message", new Collection<FieldDescription> { new ("Name") });
+        var answer = taskUserInterface.Prompt("Caption", "Message", new Collection<FieldDescription> { new("Name") });
         Assert.AreEqual(1, answer.Count);
 
         Assert.Throws<NotImplementedException>(() => taskUserInterface.PromptForCredential("Caption", "Message", "UserName", "TargetName"));

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.Tests/UnitTests.cs
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.Tests/UnitTests.cs
@@ -37,7 +37,7 @@ public class UnitTests
         echo ""Start of process""
         write-output ""my test param: $testParam""
         ";
-        
+
         var result = PowerShell.RunScript(new RunScriptInput
         {
             Parameters = new[] { new PowerShellParameter { Name = "testParam", Value = "my test param" } },

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.Tests/UnitTests.cs
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.Tests/UnitTests.cs
@@ -30,6 +30,29 @@ public class UnitTests
     }
 
     [Test]
+    public void RunScript_ShouldRunFromNativeShell()
+    {
+        var script = @"
+        param([string]$testParam)
+        echo ""Start of process""
+        write-output ""my test param: $testParam""
+        ";
+        
+        var result = PowerShell.RunScript(new RunScriptInput
+        {
+            Parameters = new[] { new PowerShellParameter { Name = "testParam", Value = "my test param" } },
+            ReadFromFile = false,
+            Script = script,
+            LogInformationStream = true,
+            ExecuteNativeShell = true
+        }, new RunOptions(), default);
+
+        Assert.That(result.Result.Count, Is.AtLeast(2));
+        Assert.That(result.Result.First(), Is.EqualTo("Start of process"));
+        Assert.That(result.Result.Last(), Is.EqualTo("my test param: my test param"));
+    }
+
+    [Test]
     public void RunScript_ShouldRunScriptWithParameter()
     {
         var script = @"param([string]$testParam)

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/Definitions/RunScriptInput.cs
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/Definitions/RunScriptInput.cs
@@ -42,6 +42,14 @@ public class RunScriptInput
     /// </summary>
     /// <example>true</example>
     public bool LogInformationStream { get; set; }
+
+    /// <summary>
+    /// Define which version of PowerShell to use.
+    /// Useful in more complex scripts, as default version supports only basic usage
+    /// </summary>
+    /// <example>false</example>
+    [DefaultValue(false)]
+    public bool ExecuteNativeShell { get; set; }
 }
 
 /// <summary>

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.csproj
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript.csproj
@@ -7,7 +7,7 @@
 	<AssemblyName>Frends.PowerShell.RunScript</AssemblyName>
 	<RootNamespace>Frends.PowerShell.RunScript</RootNamespace>
 
-	<Version>1.2.0</Version>
+	<Version>1.3.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/PowerShell.cs
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/PowerShell.cs
@@ -44,9 +44,9 @@ public static class PowerShell
             {
                 File.WriteAllText(tempScript, script, Encoding.UTF8);
                 if (input.ExecuteNativeShell)
-                return ExecuteProcess(tempScript, input.Parameters);
-                else 
-                return ExecuteCommand(tempScript, input.Parameters, input.LogInformationStream, session.PowerShell, cancellationToken);
+                    return ExecuteProcess(tempScript, input.Parameters);
+                else
+                    return ExecuteCommand(tempScript, input.Parameters, input.LogInformationStream, session.PowerShell, cancellationToken);
             }
             finally
             {
@@ -55,7 +55,8 @@ public static class PowerShell
         });
     }
 
-    private static PowerShellResult ExecuteProcess(string scriptPath, PowerShellParameter[] parameters){
+    private static PowerShellResult ExecuteProcess(string scriptPath, PowerShellParameter[] parameters)
+    {
         List<dynamic> results = new();
         List<string> errors = new();
 
@@ -73,7 +74,8 @@ public static class PowerShell
         {
             FileName = "powershell.exe",
             Arguments = $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\" {parameterString}",
-            UseShellExecute = false,CreateNoWindow = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
             RedirectStandardError = true,
             RedirectStandardOutput = true,
         };

--- a/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/PowerShell.cs
+++ b/Frends.PowerShell.RunScript/Frends.PowerShell.RunScript/PowerShell.cs
@@ -103,6 +103,7 @@ public static class PowerShell
         }
         finally
         {
+            if (!process.HasExited) process.Kill();
             process.Close();
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added option to run PowerShell commands and scripts using native shell execution.
	- Introduced `ExecuteNativeShell` parameter for more flexible PowerShell interactions.

- **Version Updates**
	- Updated `Frends.PowerShell.RunCommand` to version 1.3.0.
	- Updated `Frends.PowerShell.RunScript` to version 1.3.0.

- **Improvements**
	- Enhanced script and command execution capabilities.
	- Expanded support for complex PowerShell script scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->